### PR TITLE
Update Duende.IdentityServer packages to rc.2

### DIFF
--- a/AspireForIdentityServer.IdentityServer/IdentityServer.csproj
+++ b/AspireForIdentityServer.IdentityServer/IdentityServer.csproj
@@ -8,8 +8,8 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
 		<PackageReference Include="Azure.Identity" Version="1.13.1" />
-		<PackageReference Include="Duende.IdentityServer" Version="7.1.0-rc.1" />
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.1.0-rc.1" />
+		<PackageReference Include="Duende.IdentityServer" Version="7.1.0-rc.2" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.1.0-rc.2" />
 
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
 


### PR DESCRIPTION
Updated the `Duende.IdentityServer` and `Duende.IdentityServer.EntityFramework` package versions from `7.1.0-rc.1` to `7.1.0-rc.2` in the `IdentityServer.csproj` file.