### PR TITLE
Merge Experimental Interceptors

### DIFF
--- a/AspireForIdentityServer.IdentityServer/Constants.cs
+++ b/AspireForIdentityServer.IdentityServer/Constants.cs
@@ -3,4 +3,5 @@
 public class ConfigurationSections
 {
     public const string ConnectionStrings = "ConnectionStrings";
+    public const string DatabaseSettings = "DatabaseSettings";
 }

--- a/AspireForIdentityServer.IdentityServer/Extensions/HostingExtensions.cs
+++ b/AspireForIdentityServer.IdentityServer/Extensions/HostingExtensions.cs
@@ -12,6 +12,7 @@ internal static class HostingExtensions
     {
         builder.Services.AddRazorPages();
 
+        builder.AddAndConfigureSqlServer();
         builder.AddAndConfigureRedisCache();
         builder.AddAndConfigureIdentityServer();
         builder.AddAndConfigureApiVersioning();

--- a/AspireForIdentityServer.IdentityServer/Extensions/WebApplicationBuilderExtensions.cs
+++ b/AspireForIdentityServer.IdentityServer/Extensions/WebApplicationBuilderExtensions.cs
@@ -7,7 +7,6 @@ using IdentityServer.SharedRepositories;
 using IdentityServer.SqlInterceptors;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using StackExchange.Redis;
 
 namespace IdentityServer.Extensions;
@@ -17,7 +16,7 @@ internal static class WebApplicationBuilderExtensions
     public static void AddAndConfigureSqlServer(this IHostApplicationBuilder builder)
     {
         // Register the interceptor in the DI container
-        builder.Services.AddSingleton<IInterceptor, CustomCommandInterceptor>();
+        builder.Services.AddSingleton<ICustomInterceptor, CustomCommandInterceptor>();
 
         // Add DbContexts
         builder.Services.AddDbContext<ConfigurationDbContext>(configuredSqlOptions());
@@ -43,7 +42,7 @@ internal static class WebApplicationBuilderExtensions
                     })
 
                 // Resolve the interceptors and add them to the optionsBuilder
-                .AddInterceptors([.. serviceProvider.GetServices<IInterceptor>().OfType<ICustomInterceptor>()]);
+                .AddInterceptors([.. serviceProvider.GetServices<ICustomInterceptor>()]);
         };
     }
 

--- a/AspireForIdentityServer.IdentityServer/Extensions/WebApplicationBuilderExtensions.cs
+++ b/AspireForIdentityServer.IdentityServer/Extensions/WebApplicationBuilderExtensions.cs
@@ -26,11 +26,13 @@ internal static class WebApplicationBuilderExtensions
         static Action<IServiceProvider, DbContextOptionsBuilder> configuredSqlOptions() => (serviceProvider, optionsBuilder) =>
         {
             var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+
             var connectionStrings = configuration.GetSection(ConfigurationSections.ConnectionStrings).Get<ConnectionStrings>();
+            var databaseSettings = configuration.GetSection(ConfigurationSections.DatabaseSettings).Get<DatabaseSettings>();
 
             optionsBuilder
                 .UseSqlServer(
-                    connectionString: connectionStrings.SqlServer,
+                    connectionString: $"{connectionStrings.SqlServer};Pooling=true;Min Pool Size={databaseSettings.MinPoolSize};Max Pool Size={databaseSettings.MaxPoolSize}",
                     sql =>
                     {
                         sql.MigrationsAssembly(typeof(Program).Assembly.GetName().Name);

--- a/AspireForIdentityServer.IdentityServer/Options/ConnectionStrings.cs
+++ b/AspireForIdentityServer.IdentityServer/Options/ConnectionStrings.cs
@@ -2,6 +2,6 @@
 
 public class ConnectionStrings : ICustomOptions
 {
-    public string SqlServer { get; set; } = String.Empty;
-    public string Redis { get; set; } = String.Empty;
+    public string SqlServer { get; init; } = String.Empty;
+    public string Redis { get; init; } = String.Empty;
 }

--- a/AspireForIdentityServer.IdentityServer/Options/DatabaseSettings.cs
+++ b/AspireForIdentityServer.IdentityServer/Options/DatabaseSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace IdentityServer.Extensions.Options;
+
+public class DatabaseSettings : ICustomOptions
+{
+    public int MinPoolSize { get; init; } = 5;
+    public int MaxPoolSize { get; init; } = 100;
+}

--- a/AspireForIdentityServer.IdentityServer/SqlInterceptors/CommandInterceptor.cs
+++ b/AspireForIdentityServer.IdentityServer/SqlInterceptors/CommandInterceptor.cs
@@ -3,7 +3,9 @@ using System.Data.Common;
 
 namespace IdentityServer.SqlInterceptors;
 
-public class CustomCommandInterceptor(ILogger<CustomCommandInterceptor> _logger) : DbCommandInterceptor
+public interface ICustomInterceptor : IInterceptor;
+
+public class CustomCommandInterceptor(ILogger<CustomCommandInterceptor> _logger) : DbCommandInterceptor, ICustomInterceptor
 {
     public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
     {

--- a/AspireForIdentityServer.IdentityServer/SqlInterceptors/CommandInterceptor.cs
+++ b/AspireForIdentityServer.IdentityServer/SqlInterceptors/CommandInterceptor.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+
+namespace IdentityServer.SqlInterceptors;
+
+public class CustomCommandInterceptor(ILogger<CustomCommandInterceptor> _logger) : DbCommandInterceptor
+{
+    public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+    {
+        _logger.LogInformation("Command Text: {CommandText}", command.CommandText);
+        return base.ReaderExecuting(command, eventData, result);
+    }
+}

--- a/AspireForIdentityServer.IdentityServer/appsettings.json
+++ b/AspireForIdentityServer.IdentityServer/appsettings.json
@@ -7,7 +7,6 @@
     "MinPoolSize": 5,
     "MaxPoolSize": 100
   },
-
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/AspireForIdentityServer.IdentityServer/appsettings.json
+++ b/AspireForIdentityServer.IdentityServer/appsettings.json
@@ -3,6 +3,11 @@
     "SqlServer": "",
     "Redis": ""
   },
+  "DatabaseSettings": {
+    "MinPoolSize": 5,
+    "MaxPoolSize": 100
+  },
+
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/AspireForIdentityServer.ServiceDefaults/AspireForIdentityServer.ServiceDefaults.csproj
+++ b/AspireForIdentityServer.ServiceDefaults/AspireForIdentityServer.ServiceDefaults.csproj
@@ -12,8 +12,8 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />

--- a/AspireForIdentityServer.Tests/AspireForIdentityServer.Tests.csproj
+++ b/AspireForIdentityServer.Tests/AspireForIdentityServer.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="9.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Adds a new experimental interceptor and interface.
- Reduce `AddConfigurationStore` and  `AddOperationalStore` by removing the options configuration.
- Refactor SQL Server configuration into a new method and incorporate the interceptor(s).
- Explicitly register the IdentityServer contexts within the new configuration method.